### PR TITLE
:wrench: fix the type stored in variant types to work cross platform

### DIFF
--- a/pre/json/detail/dejsonizer.hpp
+++ b/pre/json/detail/dejsonizer.hpp
@@ -3,7 +3,6 @@
 
 #include <variant>
 #include <optional>
-#include <boost/type_index.hpp>
 
 #include <boost/mpl/for_each.hpp>
 #include <boost/fusion/include/for_each.hpp>
@@ -13,6 +12,7 @@
 #include <nlohmann/json.hpp>
 
 #include <pre/json/detail/sfinae_enabler.hpp>
+#include <pre/json/detail/get_type_name_as_string.hpp>
 #include <pre/enums/to_underlying.hpp>
 
 #include <pre/variant/for_each_type.hpp>
@@ -78,7 +78,7 @@ namespace pre { namespace json { namespace detail {
             auto struct_it = _json_object.find("struct");
             
             if ( (struct_it != _json_object.end()) && 
-                (*struct_it == boost::typeindex::type_id<U>().pretty_name()) ) {
+                (*struct_it == get_type_name_as_string<U>()) ) {
 
               dejsonizer dejsonizer(_json_object);
               U test_value;

--- a/pre/json/detail/get_type_name_as_string.hpp
+++ b/pre/json/detail/get_type_name_as_string.hpp
@@ -1,0 +1,24 @@
+#ifndef PRE_JSON_DETAIL_GET_TYPE_NAME_AS_STRING_HPP
+#define PRE_JSON_DETAIL_GET_TYPE_NAME_AS_STRING_HPP
+
+#include <boost/type_index.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace pre { namespace json { namespace detail {
+
+  template<class T>
+  inline std::string get_type_name_as_string() {
+  
+    using namespace boost::algorithm;
+    auto pretty_name = boost::typeindex::type_id<T>().pretty_name();
+    if (starts_with(pretty_name, "struct ")) {
+      return replace_first_copy(pretty_name, "struct ", "");
+    } else if (starts_with(pretty_name, "class ")) {
+      return replace_first_copy(pretty_name, "class ", "");
+    } else {
+      return pretty_name;
+    }
+  }
+}}}
+
+#endif

--- a/pre/json/detail/jsonizer.hpp
+++ b/pre/json/detail/jsonizer.hpp
@@ -3,7 +3,6 @@
 
 #include <variant>
 #include <optional>
-#include <boost/type_index.hpp>
 
 #include <boost/fusion/include/for_each.hpp>
 
@@ -12,6 +11,7 @@
 #include <nlohmann/json.hpp>
 
 #include <pre/json/detail/sfinae_enabler.hpp>
+#include <pre/json/detail/get_type_name_as_string.hpp>
 #include <pre/enums/to_underlying.hpp>
 #include <pre/variant/apply_visitor.hpp>
 
@@ -57,7 +57,7 @@ namespace pre { namespace json { namespace detail {
     void operator()(const T& value) const {
 
       if (_disambiguate_struct) {
-        _json_object["struct"] = boost::typeindex::type_id<T>().pretty_name();
+        _json_object["struct"] =  get_type_name_as_string<T>();
         _disambiguate_struct = false; // Do it only once in hierarchy
       }
       pre::fusion::for_each_member(value, *this);


### PR DESCRIPTION
msvc type_index yields a "struct namespace::type" while gcc and clang yields "namespace::type" directly.

This should fix it however it's somewhat ugly, a better solution based on a fix withing typeindex needs to be envisioned. 

The reason I used typeindex in the first place was actually to avoid doing such stuffs...
