### PR TITLE
Feature/property name mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,30 +6,20 @@ jobs:
   build-wasm: 
     name: build-wasm
     runs-on: ubuntu-latest
-    container: nxxm/nxxm-ubuntu-develop
+    container: tipibuild/tipi-ubuntu
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: nxxm builds project 
         run: |
-          nxxm . --dont-upgrade --verbose --test all 
-  build-gcc: 
-    name: build-gcc
-    runs-on: ubuntu-latest
-    container: nxxm/nxxm-ubuntu-develop
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: nxxm builds project 
-        run: |
-          nxxm . --dont-upgrade --verbose --test all -t gcc-7-cxx17
+          tipi . --dont-upgrade --verbose --test all -t wasm-cxx17
   build-clang-linux: 
     name: build-clang-linux
     runs-on: ubuntu-latest
-    container: nxxm/nxxm-ubuntu-develop
+    container: tipibuild/tipi-ubuntu
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: nxxm builds project 
         run: |
-          nxxm . --dont-upgrade --verbose --test all -t linux
+          tipi . --dont-upgrade --verbose --test all -t linux-cxx17

--- a/.nxxm/deps
+++ b/.nxxm/deps
@@ -1,4 +1,0 @@
-{
-  "nlohmann/json" :  { "@" : "v3.1.2", "x" : ["benchmarks"] }
-  , "platform" : [ "Boost::+boost" ]
-}

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,0 +1,4 @@
+{
+  "nlohmann/json" :  { "@" : "v3.11.1", "x" : ["benchmarks"] }
+  , "platform" : [ "Boost::+boost" ]
+}

--- a/examples/from_json.cpp
+++ b/examples/from_json.cpp
@@ -1,26 +1,72 @@
 #include <iostream>
 #include <pre/json/from_json.hpp> 
+#include <pre/json/mapping.hpp>
+#include <nlohmann/json.hpp>
+
  
 struct customer {
   std::string name;
   size_t money_spent; 
   std::vector<std::string> interests;
+  std::optional<bool> is_private;  // this property shall be mapped to the "private" key in the json
+  std::vector<int> numbers;
 };
 
 BOOST_FUSION_ADAPT_STRUCT(customer,
   name,
   money_spent,
-  interests)
+  interests,
+  is_private,
+  numbers)
 
 int main() {
 
+
   std::string string_to_deserialize = 
-    "{\"interests\":[\"sport articles\"], \"money_spent\":50, \"name\":\"Mrs. Fraulein\"}";
+    "{\"interests\":[\"sport articles\"], \"money_spent\":50, \"name\":\"Mrs. Fraulein\", \"private\": true, \"numbers\": [1,2,3]}";
 
-  customer my_customer = pre::json::from_json<customer>(string_to_deserialize);
+  // classic deserialization
+  {
+    customer my_customer = pre::json::from_json<customer>(string_to_deserialize);
 
-  std::cout << "Customer " << my_customer.name << " spent " <<
-    my_customer.money_spent << std::endl;
+    std::cout << "Customer " << my_customer.name << " spent " <<
+      my_customer.money_spent << std::endl;
+  }
+
+  // with mapping deserialization
+  {
+    customer my_customer = pre::json::from_json<customer>(string_to_deserialize, [](nlohmann::json& jdoc) {
+      jdoc["is_private"] = jdoc["private"];
+      jdoc.erase("private");
+    });
+
+    std::cout << "Customer " << my_customer.name << " spent " <<
+      my_customer.money_spent << " is private:" << std::to_string(my_customer.is_private.value()) << std::endl;
+  }
+
+  // with mapping helpers
+  {
+    customer my_customer = pre::json::from_json<customer>(string_to_deserialize, [](nlohmann::json& jdoc) {
+      pre::json::remap_property(jdoc, "private", "is_private");
+    });
+
+    std::cout << "Customer " << my_customer.name << " spent " <<
+      my_customer.money_spent << " is private:" << std::to_string(my_customer.is_private.value()) << std::endl;
+  }
+
+  // with mapping and json_pointer helpers
+  {
+    std::string string_to_deserialize = 
+    "{\"interests\":[\"sport articles\"], \"money_spent\":50, \"name\":\"Mrs. Fraulein\", \"private\": true, \"numbers\": [1,2,3]}";
+
+    customer my_customer = pre::json::from_json<customer>(string_to_deserialize, [](nlohmann::json& jdoc) {
+      pre::json::remap_property(jdoc, "/private"_json_pointer, "/is_private"_json_pointer);
+      pre::json::remap_property(jdoc, "/numbers/0"_json_pointer, "/numbersNew/2"_json_pointer);
+      pre::json::remap_property(jdoc, "/money_spent"_json_pointer, "/numbers/0"_json_pointer);
+      jdoc["money_spent"] = 0;
+      std::cout << jdoc.dump(2) << std::endl; 
+    });
+  } 
 
   return 0;
 }

--- a/examples/to_json.cpp
+++ b/examples/to_json.cpp
@@ -1,26 +1,43 @@
 #include <iostream>
 #include <pre/json/to_json.hpp>
+#include <pre/json/mapping.hpp>
 
 struct customer {
   std::string name;
   size_t money_spent;
   std::vector<std::string> interests;
+  bool is_private;
 };
 
 BOOST_FUSION_ADAPT_STRUCT(customer,
   name,
   money_spent,
-  interests)
+  interests,
+  is_private)
 
 
 int main() {
 
-  customer my_customer{
-    "Mr. Dupond",
-    1000,
-    {"sport articles", "food", "tools"}
-  };
+  {
+    customer my_customer{
+      "Mr. Dupond",
+      1000,
+      {"sport articles", "food", "tools"},
+      true
+    };
 
-  std::cout << pre::json::to_json(my_customer) << std::endl;
+    std::cout << pre::json::to_json(my_customer) << std::endl;
+
+    // with remapping
+    std::cout << "With property 'is_private' mapped to 'private':\n" 
+      << pre::json::to_json(
+        my_customer, 
+        [](auto &jdoc) { 
+          pre::json::remap_property(jdoc, "/is_private"_json_pointer, "/private"_json_pointer);
+        }) 
+      << std::endl;
+  }
+
+
   return 0;
 }

--- a/pre/json/from_json.hpp
+++ b/pre/json/from_json.hpp
@@ -74,6 +74,19 @@ namespace pre { namespace json {
   }
 
   /**
+   * \brief Same as pre::json::from_json(const std::string&) but with an added mapper function
+   */
+  template<class T>
+  T from_json(const std::string& serialized_json, std::function<void(nlohmann::json&)> mapper) {
+    nlohmann::json json_object = nlohmann::json::parse(serialized_json);
+    mapper(json_object);  // does whatever mapping is required
+    T object;
+    detail::dejsonizer dejsonizer(json_object);
+    dejsonizer(object);
+    return object;
+  }
+
+  /**
    * \brief Same as pre::json::from_json(const std::string&) but directly with a JSON.
    */
   template<class T>

--- a/pre/json/mapping.hpp
+++ b/pre/json/mapping.hpp
@@ -1,0 +1,64 @@
+#ifndef PRE_JSON_MAPPING_HPP
+#define PRE_JSON_MAPPING_HPP
+
+#include <nlohmann/json.hpp>
+#include <nlohmann/thirdparty/hedley/hedley_undef.hpp>
+
+namespace pre { 
+    namespace json {
+
+
+        /**
+         * @brief "Rername" a json key in the JSON object
+         * 
+         * @param jdoc 
+         * @param psource source key name
+         * @param pdest destination key name
+         */
+        inline void remap_property(nlohmann::json& jdoc, std::string psource, std::string pdest) {
+            jdoc[pdest] = jdoc[psource];
+            jdoc.erase(psource);
+        }
+
+        inline void remap_property(nlohmann::json& jdoc, 
+            nlohmann::json::json_pointer psource, 
+            nlohmann::json::json_pointer pdest
+        ) {
+            // get reference to parent of JSON pointer ptr
+            const auto original_psource = psource;
+            const auto last_path = psource.back();
+            psource.pop_back();
+            auto& parent = jdoc.at(psource);
+
+            // remove child
+            if (parent.is_object())
+            {
+                auto it = parent.find(last_path);
+                if (it != parent.end())
+                {
+                    jdoc[pdest] = jdoc[original_psource];
+                    parent.erase(it);
+                }
+                else
+                {
+                    throw std::runtime_error("Could not find json key at: " + original_psource.to_string());
+                }
+            }
+            else if (parent.is_array())
+            {
+                auto ix_deletion = std::stoi(last_path);
+                auto value = jdoc[original_psource]; // copy source before deleting it
+
+                if(ix_deletion >= parent.size()) {
+                    throw std::runtime_error("Index out of range when accessing array at: " + original_psource.to_string());
+                }
+
+                parent.erase(ix_deletion);   // no need to range check manually, erase() does it already
+                jdoc[pdest] = value;
+                
+            }
+        }
+    }
+}
+
+#endif

--- a/pre/json/to_json.hpp
+++ b/pre/json/to_json.hpp
@@ -68,6 +68,22 @@ namespace pre { namespace json {
     return json_object;
   }
 
+  /**
+   * \brief Same as pre::json::to_json<T>(const T&) but with a post serialization mapper function
+   * 
+   * \tparam T 
+   * \param value 
+   * \param mapper 
+   * \return An [nlohmann::json](https://github.com/nlohmann/json/) object directly streamable to std::cout or convertible to string.
+   */
+  template<class T>
+  nlohmann::json to_json(const T& value, std::function<void(nlohmann::json&)> mapper) {
+    nlohmann::json json_object;
+    detail::jsonizer jsonizer(json_object);
+    jsonizer(value);
+    mapper(json_object);
+    return json_object;
+  }
 }}
 
 #endif


### PR DESCRIPTION
Implemented a relatively Q&D support for property name remapping to allow us to deal with JSON keys like `private` or `public` or other keywords reserved in C++ that give us a hard time to write up the serialization/deserialization with `boost::fusion`