### PR TITLE
Fix empty maps roundtrip and move to native tipi deps

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,8 +1,7 @@
 { 
   "nlohmann/json" :  { "@" : "v3.11.2", "x" : ["benchmarks"] }
-  , "tipi-deps/boost" : {
-      "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
-    , "@" : "v1.80.0-without-submodules"
+  , "boostorg/boost" : {
+    , "@" : "v1.80.0"
     , "u" : true
     , "opts" : "set(BOOST_INCLUDE_LIBRARIES fusion)"
     , "packages" : ["boost_fusion"]

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,8 +1,10 @@
 { 
   "nlohmann/json" :  { "@" : "v3.11.2", "x" : ["benchmarks"] }
-  , "tipi-deps/boost" : { 
-      "@" : "v1.80.0-without-submodules"
+  , "tipi-deps/boost" : {
+      "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
+    , "@" : "v1.80.0-without-submodules"
     , "u" : true
+    , "opts" : "set(BOOST_INCLUDE_LIBRARIES fusion)"
     , "packages" : ["boost_fusion"]
     , "targets" : ["Boost::fusion"] 
   }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,4 +1,9 @@
-{
-  "nlohmann/json" :  { "@" : "v3.11.1", "x" : ["benchmarks"] }
-  , "platform" : [ "Boost::+boost" ]
+{ 
+  "nlohmann/json" :  { "@" : "v3.11.2", "x" : ["benchmarks"] }
+  , "tipi-deps/boost" : { 
+      "@" : "v1.80.0-without-submodules"
+    , "u" : true
+    , "packages" : ["boost_fusion"]
+    , "targets" : ["Boost::fusion"] 
+  }
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,7 +1,7 @@
 { 
   "nlohmann/json" :  { "@" : "v3.11.2", "x" : ["benchmarks"] }
   , "boostorg/boost" : {
-    , "@" : "v1.80.0"
+      "@" : "v1.80.0"
     , "u" : true
     , "opts" : "set(BOOST_INCLUDE_LIBRARIES fusion)"
     , "packages" : ["boost_fusion"]

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,7 +1,7 @@
 { 
   "nlohmann/json" :  { "@" : "v3.11.2", "x" : ["benchmarks"] }
   , "boostorg/boost" : {
-      "@" : "v1.80.0"
+      "@" : "boost-1.80.0"
     , "u" : true
     , "opts" : "set(BOOST_INCLUDE_LIBRARIES fusion)"
     , "packages" : ["boost_fusion"]

--- a/.tipi/id
+++ b/.tipi/id
@@ -1,0 +1,1 @@
+{"host_name":"github.com","org_name":"cpp-pre","repo_name":"json"}

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,0 +1,1 @@
+set(BOOST_INCLUDE_LIBRARIES fusion)

--- a/pre/json/detail/jsonizer.hpp
+++ b/pre/json/detail/jsonizer.hpp
@@ -111,6 +111,7 @@ namespace pre { namespace json { namespace detail {
     template<class T, 
       enable_if_is_associative_container_t<T>* = nullptr>
     void operator()(const T& value) const {
+      _json_object = nlohmann::json::object();
       for (const auto& each : value) {
         nlohmann::json json_subobject;
         jsonizer subjsonizer(json_subobject);

--- a/test/dejsonize_test.cpp
+++ b/test/dejsonize_test.cpp
@@ -400,6 +400,24 @@ BOOST_AUTO_TEST_CASE(maps) {
   BOOST_REQUIRE(some_deserialized == some); 
 }
 
+BOOST_AUTO_TEST_CASE(empty_map) {
+
+  std::map<std::string, std::string> some{};
+
+  auto some_json = pre::json::to_json(some);
+  std::cout << some_json.dump(2) << std::endl; 
+
+  auto some_deserialized = pre::json::from_json<decltype(some)>(some_json);
+  
+  BOOST_REQUIRE(some_deserialized == some); 
+
+  auto empty_map = pre::json::to_json( std::map<std::string, std::string> {} ).dump();
+  BOOST_REQUIRE(empty_map != "null");
+  BOOST_REQUIRE(empty_map == "{}");
+}
+
+
+
 
 namespace datamodel {
 


### PR DESCRIPTION
This reinstate the move to tipi-deps new style with caching + the fix for the roundtrip bug.

Was approved by @pysco in #6 